### PR TITLE
2801-bump-circleci-resource-class: Sets resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ jobs:
     working_directory: ~/onrr.gov-site/frontend
     docker:
       - image: cimg/node:16.16
+    resource_class: xlarge
     steps:
       - checkout:
           path: ~/onrr.gov-site
@@ -38,6 +39,7 @@ jobs:
     working_directory: ~/onrr.gov-site/frontend
     docker:
       - image: cimg/node:16.16
+    resource_class: xlarge
     steps:
       - checkout:
           path: ~/onrr.gov-site
@@ -66,6 +68,7 @@ jobs:
     working_directory: ~/onrr.gov-site/frontend
     docker:
       - image: cimg/node:16.16
+    resource_class: xlarge
     steps:
       - checkout:
           path: ~/onrr.gov-site


### PR DESCRIPTION
This PR consists only of the change to config.yml for bumping the resource class. I used the circleci command line tool locally to validate the file prior to committing.