### PR TITLE
Fixes incorrect search path for mobile

### DIFF
--- a/frontend/src/components/toolbars/AppToolbar.vue
+++ b/frontend/src/components/toolbars/AppToolbar.vue
@@ -90,7 +90,7 @@
       <v-list dense>
         <v-list-item-group>
           <v-list-item
-            to="/search-results"
+            to="https://search.usa.gov/search?affiliate=onrr.gov"
           >
             <v-list-item-icon>
               <v-icon>mdi-magnify</v-icon>


### PR DESCRIPTION
Incorrect path of `/search-results/` has been updated to `https://search.usa.gov/search?affiliate=onrr.gov`.