### PR TITLE
Fixes mobile side menu search bug

### DIFF
--- a/frontend/src/components/toolbars/AppToolbar.vue
+++ b/frontend/src/components/toolbars/AppToolbar.vue
@@ -90,7 +90,7 @@
       <v-list dense>
         <v-list-item-group>
           <v-list-item
-            to="https://search.usa.gov/search?affiliate=onrr.gov"
+            href="https://search.usa.gov/search?affiliate=onrr.gov"
           >
             <v-list-item-icon>
               <v-icon>mdi-magnify</v-icon>

--- a/frontend/src/components/toolbars/AppToolbar.vue
+++ b/frontend/src/components/toolbars/AppToolbar.vue
@@ -90,7 +90,7 @@
       <v-list dense>
         <v-list-item-group>
           <v-list-item
-            to="/search-results"
+            to="https://search.usa.gov/search?affiliate=onrr.gov"
           >
             <v-list-item-icon>
               <v-icon>mdi-magnify</v-icon>


### PR DESCRIPTION
Go to [dev](https://dev-onrr-frontend.app.cloud.gov) and enter Responsive Design mode. The hamburger should appear and the search link should take the user to the search.usa.gov page.